### PR TITLE
reference: fix up guide link text

### DIFF
--- a/app/helpers/doc_helper.rb
+++ b/app/helpers/doc_helper.rb
@@ -1,7 +1,7 @@
 module DocHelper
 
-  def man(name)
-    link_to name.gsub(/^git-/, ''), doc_file_path(:file => name)
+  def man(name, text = nil)
+    link_to text || name.gsub(/^git-/, ''), doc_file_path(:file => name)
   end
 
   def linkify(content, section)

--- a/app/views/shared/ref/_guides.html.erb
+++ b/app/views/shared/ref/_guides.html.erb
@@ -1,11 +1,11 @@
 <h3 class='guides'>Guides</h3>
 <ul class='unstyled'>
   <li><%= man('gitattributes') %></li>
-  <li><%= man('giteveryday') %></li>
-  <li><%= man('gitglossary') %></li>
+  <li><%= man('giteveryday', 'Everyday Git') %></li>
+  <li><%= man('gitglossary', 'Glossary') %></li>
   <li><%= man('gitignore') %></li>
   <li><%= man('gitmodules') %></li>
-  <li><%= man('gitrevisions') %></li>
-  <li><%= man('gittutorial') %></li>
-  <li><%= man('gitworkflows') %></li>
+  <li><%= man('gitrevisions', 'Revisions') %></li>
+  <li><%= man('gittutorial', 'Tutorial') %></li>
+  <li><%= man('gitworkflows', 'Workflows') %></li>
 </ul>


### PR DESCRIPTION
For guides like `giteveryday`, we format the link text as just `everyday`. This is due to d417f6b (doc_helper: handle topic guides in man() linker, 2016-09-21).

That behavior was lost in 244936d (Add git(1) to command reference, 2017-01-08), which tightened the regex to avoid turning just `git` into nothing.

We could fix that regression, but let's go a step further. Some of the guide names, like `gitignore`, actually _should_ retain their `git` names. And other guides, like `giteveryday`, could have better human-readable names.

Let's give the `man()` helper an optional parameter for the link text, and give all of the guides better names.
